### PR TITLE
Fixed video and poster import path

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,8 +9,8 @@
         </div>
     </div>
     <div class="Banner-VideoContainer">
-        <video playsinline autoplay muted loop poster="banner-poster.jpg">
-            <source src="banner-video.mp4" type="video/mp4">
+        <video playsinline autoplay muted loop poster="/banner-poster.jpg">
+            <source src="/banner-video.mp4" type="video/mp4">
         </video>
     </div>
 </section>


### PR DESCRIPTION
Changed relative path of video and poster import to an absolute one, as suggested in #61 by @ioboi 